### PR TITLE
Fix a typo

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -154,6 +154,7 @@ Libbeacon.prototype.get = function(path, opts, cb) {
   });
   options.url = this.baseUrl + 'Api/v1/' + path;
   options.headers['Cookie'] = this.sessionCookieName + '=' + this.cookie;
+  options.headers['User-Agent'] = this._userAgent;
   var req = this._request(options, function(error, response, body) {
     if(error) {
       cb && cb(error);


### PR DESCRIPTION
This line already seemed to be in my copy from 'npm install', but it had 'this.userAgent' instead of 'this._userAgent'. Fetching from beacon seems to work now on my PC.